### PR TITLE
Change comment to match the existing code/data

### DIFF
--- a/ember/features.py
+++ b/ember/features.py
@@ -164,7 +164,7 @@ class SectionInfo(FeatureType):
         sections = raw_obj['sections']
         general = [
             len(sections),  # total number of sections
-            # number of sections with nonzero size
+            # number of sections with zero size
             sum(1 for s in sections if s['size'] == 0),
             # number of sections with an empty name
             sum(1 for s in sections if s['name'] == ""),


### PR DESCRIPTION
Fixes #72

I intended to use `!= 0`. But `== 0` will result in the same classification performance. And feature engineering can be used to generate whatever other features a user might want. So I'll just change the comment to reflect what's actually in the code/data.